### PR TITLE
Untersuchung des fehlgeschlagenen deploy workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
           - app-type: cdk
             deploy-tag-suffix: cdk-deployed
             exclude-pattern: '*,!tag:cdk'
-            extra-deploy-args: '-- --require-approval=never'
+            extra-deploy-args: '--require-approval=never'
     steps:
       - run: echo "Release process starting for ${{ matrix.config.app-type }} apps version ${{ env.RELEASE_VERSION }}"
 

--- a/apps/angular-examples-cdk/project.json
+++ b/apps/angular-examples-cdk/project.json
@@ -10,7 +10,8 @@
       "dependsOn": ["^build"],
       "executor": "@wolsok/nx-aws-cdk-v2:deploy",
       "options": {
-        "output": "{workspaceRoot}/dist/{projectRoot}"
+        "output": "{workspaceRoot}/dist/{projectRoot}",
+        "requireApproval": "never"
       }
     },
     "destroy": {

--- a/apps/bacteria-game-remote-cdk/project.json
+++ b/apps/bacteria-game-remote-cdk/project.json
@@ -10,7 +10,8 @@
       "dependsOn": ["^build"],
       "executor": "@wolsok/nx-aws-cdk-v2:deploy",
       "options": {
-        "output": "{workspaceRoot}/dist/{projectRoot}"
+        "output": "{workspaceRoot}/dist/{projectRoot}",
+        "requireApproval": "never"
       }
     },
     "destroy": {

--- a/apps/fourier-analysis-remote-cdk/project.json
+++ b/apps/fourier-analysis-remote-cdk/project.json
@@ -10,7 +10,8 @@
       "dependsOn": ["^build"],
       "executor": "@wolsok/nx-aws-cdk-v2:deploy",
       "options": {
-        "output": "{workspaceRoot}/dist/{projectRoot}"
+        "output": "{workspaceRoot}/dist/{projectRoot}",
+        "requireApproval": "never"
       }
     },
     "destroy": {

--- a/apps/shader-examples-remote-cdk/project.json
+++ b/apps/shader-examples-remote-cdk/project.json
@@ -10,7 +10,8 @@
       "dependsOn": ["^build"],
       "executor": "@wolsok/nx-aws-cdk-v2:deploy",
       "options": {
-        "output": "{workspaceRoot}/dist/{projectRoot}"
+        "output": "{workspaceRoot}/dist/{projectRoot}",
+        "requireApproval": "never"
       }
     },
     "destroy": {


### PR DESCRIPTION
Fix CDK deploy workflow by correcting argument passing and explicitly setting `requireApproval`.

The `nx-aws-cdk-v2` package version 2.3.1 did not correctly interpret CDK arguments passed via the `extra-deploy-args` when a `--` separator was present, leading to failed deployments. Removing this separator in the workflow and adding `requireApproval: "never"` directly to the CDK project configurations ensures correct argument parsing and provides a robust, explicit setting for CDK deployments.