### PR TITLE
Integrate Nx release version command into release workflow

### DIFF
--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -24,11 +24,16 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.no-reply.github.com"
           git config --local user.name "github-actions[bot]"
-          if [[ -z "$(git tag -l 'ws-thanos@*' 'spa-cdk-stack@*')" ]]; then
-            npx nx release version --first-release
-          else
-            npx nx release version
-          fi
+
+          first_release_flag=""
+          for project in $(npx nx show projects --projects='tag:published'); do
+            if [[ -z "$(git tag -l "${project}@*")" ]]; then
+              first_release_flag="--first-release"
+              break
+            fi
+          done
+
+          npx nx release version $first_release_flag
           npx commit-and-tag-version
 
       - name: Push changes

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -21,10 +21,14 @@ jobs:
           node-version-file: '.nvmrc'
           cache: npm
 
+      - name: install dependencies
+        run: npm ci --ignore-scripts
+
       - name: trigger release
         run: |
           git config --local user.email "github-actions[bot]@users.no-reply.github.com"
           git config --local user.name "github-actions[bot]"
+          npx nx release version
           npx commit-and-tag-version
 
       - name: Push changes

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -24,7 +24,11 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.no-reply.github.com"
           git config --local user.name "github-actions[bot]"
-          npx nx release version
+          if [[ -z "$(git tag -l 'ws-thanos@*' 'spa-cdk-stack@*')" ]]; then
+            npx nx release version --first-release
+          else
+            npx nx release version
+          fi
           npx commit-and-tag-version
 
       - name: Push changes

--- a/.github/workflows/trigger-release.yml
+++ b/.github/workflows/trigger-release.yml
@@ -16,13 +16,9 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: npm
 
-      - name: install dependencies
-        run: npm ci --ignore-scripts
+      - name: Install Deps
+        uses: ./.github/actions/install-deps
 
       - name: trigger release
         run: |

--- a/nx.json
+++ b/nx.json
@@ -280,7 +280,11 @@
       }
     },
     "version": {
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "git": {
+        "commit": true,
+        "tag": true
+      }
     }
   },
   "defaultProject": "angular-examples",

--- a/nx.json
+++ b/nx.json
@@ -74,7 +74,7 @@
     ]
   },
   "targetDefaults": {
-    "release": {
+    "nx-release-publish": {
       "dependsOn": ["build"]
     },
     "deploy": {


### PR DESCRIPTION
## Summary
Updated the release workflow to use Nx's native release versioning tool alongside the existing commit-and-tag-version process, and aligned the Nx configuration to use the correct target name for release publishing.

## Key Changes
- Added `npm ci --ignore-scripts` step to install dependencies before running release commands
- Integrated `npx nx release version` command into the release workflow to leverage Nx's release management capabilities
- Renamed the Nx target from `release` to `nx-release-publish` in `nx.json` to align with Nx's standard release target naming conventions and ensure proper dependency resolution during the publish phase

## Implementation Details
The workflow now executes the Nx release version command before the existing commit-and-tag-version tool, allowing both tools to work together in the release process. The dependency configuration update ensures that the `build` target is properly executed before the `nx-release-publish` target runs.

https://claude.ai/code/session_01Uoo6FtUZQZDGjFWFZ9fiMi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimierung des Release-Workflows durch verbesserte Abhängigkeitsverwaltung und Anpassung der Befehlsreihenfolge in der Release-Pipeline
  * Konfigurationsupdate der Build-Tools zur Verbesserung der Kompatibilität und Zuverlässigkeit des Release-Prozesses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->