### PR TITLE
fix(feat-lazy-bacteria-game): align @wolsok/thanos peer dep with inst…

### DIFF
--- a/libs/features/lazy/bacteria-game/package.json
+++ b/libs/features/lazy/bacteria-game/package.json
@@ -6,7 +6,7 @@
     "@angular/core": "20.3.7",
     "@angular/material": "20.2.10",
     "@ngneat/until-destroy": "10.0.0",
-    "@wolsok/thanos": "16.1.0",
+    "@wolsok/thanos": "17.0.0",
     "@wolsok/ui-kit": "0.0.1",
     "rxjs": "7.8.2",
     "@angular/router": "20.3.7",


### PR DESCRIPTION
…alled 17.0.0

Resolves @nx/dependency-checks lint error where the peer dependency specifier (16.1.0) did not include the installed version (17.0.0).

https://claude.ai/code/session_01WjAxMscdHTYgF5ekggMG9T