### PR TITLE
fix(feat-lazy-bacteria-game): resolve lint error blocking main CI

### DIFF
--- a/libs/features/lazy/bacteria-game/package.json
+++ b/libs/features/lazy/bacteria-game/package.json
@@ -6,7 +6,7 @@
     "@angular/core": "20.3.7",
     "@angular/material": "20.2.10",
     "@ngneat/until-destroy": "10.0.0",
-    "@wolsok/thanos": "17.0.0",
+    "@wolsok/thanos": "17.0.1",
     "@wolsok/ui-kit": "0.0.1",
     "rxjs": "7.8.2",
     "@angular/router": "20.3.7",


### PR DESCRIPTION
Fixes the lint error in `feat-lazy-bacteria-game` that caused main CI to fail since Jun 15 (run `27527215487`). Closes #2137

## Root cause

The `@nx/dependency-checks` ESLint rule caught a version mismatch in `libs/features/lazy/bacteria-game/package.json`:

- **Declared** peerDependency: `"@wolsok/thanos": "17.0.0"`
- **Installed** version in the monorepo (`libs/public/ws-thanos/package.json`): `17.0.1`

The rule requires the declared version to exactly match the installed version. When `@wolsok/thanos` was bumped to `17.0.1` the bacteria-game `package.json` was not updated, leaving the peerDependency stale.

## Fix

One-line change: bump `@wolsok/thanos` peerDependency in `libs/features/lazy/bacteria-game/package.json` from `17.0.0` → `17.0.1`.

Links to nightshift dashboard: https://github.com/WolfSoko/wol-sok-mono/issues/2111

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkRPW6BUj9Wn9VHYXgo2Dz)_