### PR TITLE
fix(feat-lazy-bacteria-game): fix lint errors breaking main CI

### DIFF
--- a/libs/features/lazy/bacteria-game/package.json
+++ b/libs/features/lazy/bacteria-game/package.json
@@ -6,7 +6,7 @@
     "@angular/core": "20.3.7",
     "@angular/material": "20.2.10",
     "@ngneat/until-destroy": "10.0.0",
-    "@wolsok/thanos": "17.0.0",
+    "@wolsok/thanos": "17.0.1",
     "@wolsok/ui-kit": "0.0.1",
     "rxjs": "7.8.2",
     "@angular/router": "20.3.7",


### PR DESCRIPTION
Closes #2139

## Summary

The `feat-lazy-bacteria-game:lint` CI target has been failing for 9 days (since Jun 15). This was the sole failing task out of 119 in CI run 27527215487, triggered by commit `c80bbe3` (which itself only touched `apps/rollapolla-analog/firestore.rules`). The lint error is pre-existing and was merely surfaced by that run.

### Root cause

`libs/features/lazy/bacteria-game/package.json` declared a peer dependency on `@wolsok/thanos` at version `17.0.0`, but the workspace package `libs/public/ws-thanos/package.json` had been bumped to `17.0.1`. The `@nx/dependency-checks` ESLint rule enforces that peer-dependency version specifiers match the installed/workspace version, so the mismatch caused:

```
/libs/features/lazy/bacteria-game/package.json
  9:5  error  The version specifier does not contain the installed version of "@wolsok/thanos" package: 17.0.1  @nx/dependency-checks
```

### Fix

Updated line 9 of `libs/features/lazy/bacteria-game/package.json`:
- Before: `"@wolsok/thanos": "17.0.0"`
- After: `"@wolsok/thanos": "17.0.1"`

This was confirmed by running `nx lint feat-lazy-bacteria-game --fix` (which applied the fix automatically), and then re-running lint without `--fix` to confirm a clean pass.

### Unblocks

This fix also unblocks PR #2128 (node version upgrade) from landing on a green `main` — that PR has been waiting on a clean CI baseline.

---

Related project board: https://github.com/WolfSoko/wol-sok-mono/issues/2111

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALMZX9ZYkjTpLmtH51Snrn)_