### PR TITLE
fix(feat-lazy-bacteria-game): fix lint error to restore main CI

### DIFF
--- a/libs/features/lazy/bacteria-game/package.json
+++ b/libs/features/lazy/bacteria-game/package.json
@@ -6,7 +6,7 @@
     "@angular/core": "20.3.7",
     "@angular/material": "20.2.10",
     "@ngneat/until-destroy": "10.0.0",
-    "@wolsok/thanos": "17.0.0",
+    "@wolsok/thanos": "17.0.1",
     "@wolsok/ui-kit": "0.0.1",
     "rxjs": "7.8.2",
     "@angular/router": "20.3.7",


### PR DESCRIPTION
## Summary

Closes #2141

Links to nightwatch dashboard: https://github.com/WolfSoko/wol-sok-mono/issues/2111

### What failed

CI/CD on `main` has been failing since Jun 15, 2026 (GitHub Actions run 27527215487). The only failing task of 119 was:

```
✖ Failed  feat-lazy-bacteria-game:lint  2s  Cache Miss
```

ESLint error:
```
/libs/features/lazy/bacteria-game/package.json
  9:5  error  The version specifier does not contain the installed version of "@wolsok/thanos" package: 17.0.1  @nx/dependency-checks
```

### Root cause

The `peerDependencies` in `libs/features/lazy/bacteria-game/package.json` referenced `"@wolsok/thanos": "17.0.0"`, but the actual package at `libs/public/ws-thanos/package.json` has version `17.0.1`. The `@nx/dependency-checks` ESLint rule enforces that declared peer dependency version specifiers match the installed version.

This was introduced by commit `c80bbe3` ("Apply suggestions from code review, Co-authored-by: Copilot Autofix") from PR #2114 — that commit bumped the thanos package version to `17.0.1` but did not update the consumer reference in the bacteria-game lib.

### Fix

**File changed:** `libs/features/lazy/bacteria-game/package.json`  
**ESLint rule:** `@nx/dependency-checks`  
**Change:** Updated `@wolsok/thanos` peerDependency from `"17.0.0"` → `"17.0.1"`

One-line diff:
```diff
-    "@wolsok/thanos": "17.0.0",
+    "@wolsok/thanos": "17.0.1",
```

Lint now passes cleanly. Main CI should be green on the next push to main.

## Test plan

- [x] `npx nx lint feat-lazy-bacteria-game` — passes with 0 errors
- [x] `npx nx test feat-lazy-bacteria-game` — passes (exits 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8eRCQtAyQcPAFf1NjDx6t

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8eRCQtAyQcPAFf1NjDx6t)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Die kompatible Version einer Peer-Abhängigkeit wurde auf **17.0.1** angehoben.
  * Keine weiteren sichtbaren Änderungen an Funktionen oder Verhalten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->