### PR TITLE
fix(ci): remove unsupported internalPackagePatterns from renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,18 +14,6 @@
   "platformAutomerge": true,
   "prCreation": "immediate",
   "rebaseWhen": "conflicted",
-  "internalPackagePatterns": [
-    "@wolsok/feat-*",
-    "@wolsok/fib-*",
-    "@wolsok/headline-*",
-    "@wolsok/shared-*",
-    "@wolsok/spa-*",
-    "@wolsok/test-*",
-    "@wolsok/thanos",
-    "@wolsok/ui-*",
-    "@wolsok/utils-*",
-    "@wolsok/ws-*"
-  ],
   "packageRules": [
     {
       "matchPackageNames": ["esbuild", "eslint-plugin-playwright"],


### PR DESCRIPTION
## Summary

Removes `internalPackagePatterns` from `.github/renovate.json`. This key was added in commits `da445c1`/`6029b56` (Jul 17) to suppress lookup-failure noise, but it is not supported by the self-hosted Renovate runner (`renovatebot/github-action v46.1.19`). Renovate treats unknown config keys as hard errors and stopped processing all dependency PRs for this repo.

Restoring the config to its pre-Jul-17 state re-enables Renovate.

Closes #2156

Related: #2155 (Renovate config error issue), https://github.com/WolfSoko/wol-sok-mono/issues/2111 (nightwatch dashboard)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FAveoTAH6pbQ4r5KenDnsM)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renovate-Konfiguration bereinigt, indem veraltete interne Paketmuster entfernt wurden.
  * Bestehende Regeln für Abhängigkeiten bleiben unverändert.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->